### PR TITLE
🔧 [Utilities] Revised `debounce` and new `noop`, `isEmpty`, and `throttle` utils

### DIFF
--- a/.changeset/mighty-spiders-help.md
+++ b/.changeset/mighty-spiders-help.md
@@ -1,0 +1,5 @@
+---
+"beeftools": patch
+---
+
+New immediate argument for debounce + a few new utilities.

--- a/src/general.ts
+++ b/src/general.ts
@@ -1,0 +1,40 @@
+import {objFilterNullish} from './object';
+
+export function noop() {}
+
+export function isEmpty(
+  value?:
+    | unknown[]
+    | Record<string, unknown>
+    | Map<unknown, unknown>
+    | Set<unknown>
+    | string
+    | number
+    | bigint
+    | boolean
+    | null,
+) {
+  // Loosely capturing anything nullish or numberish,
+  // but strictly checking against boolean.
+  if (
+    value == null ||
+    typeof value === 'boolean' ||
+    typeof value === 'number' ||
+    typeof value === 'bigint'
+  ) {
+    return true;
+  }
+
+  if (Array.isArray(value) || typeof value === 'string') {
+    return !value.length;
+  }
+
+  if (value instanceof Map || value instanceof Set) {
+    return !value.size;
+  }
+
+  const filteredObj = objFilterNullish(value);
+  const objKeys = Object.keys(filteredObj);
+
+  return !objKeys.length;
+}

--- a/src/tests/array.test.ts
+++ b/src/tests/array.test.ts
@@ -70,6 +70,20 @@ describe('array utilities', () => {
       const result = arrayShallowEquals([true, false], [false, true]);
       expect(result).toBe(false);
     });
+
+    it('returns `true` when sorting is applied ahead of time', async () => {
+      const original1 = ['a', 'B', 'c', 'D', 'e', 'F'];
+      const original2 = ['F', 'e', 'D', 'c', 'B', 'a'];
+
+      const resultBefore = arrayShallowEquals(original1, original2);
+      expect(resultBefore).toBe(false);
+
+      const sorted1 = original1.toSorted();
+      const sorted2 = original2.toSorted();
+
+      const resultAfter = arrayShallowEquals(sorted1, sorted2);
+      expect(resultAfter).toBe(true);
+    });
   });
 
   describe('arrayShuffle()', () => {

--- a/src/tests/general.test.ts
+++ b/src/tests/general.test.ts
@@ -1,0 +1,138 @@
+import {describe, it, expect} from 'vitest';
+
+import {noop, isEmpty} from '../general';
+import {objFilterNullish} from '../object';
+
+describe('general utilities', () => {
+  describe('noop()', () => {
+    it('returns `undefined`', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
+      const result = noop();
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('isEmpty()', () => {
+    describe('automatic `true` result', () => {
+      it('returns `true` for nullish values', async () => {
+        const result1 = isEmpty();
+        const result2 = isEmpty(undefined);
+        const result3 = isEmpty(null);
+
+        expect(result1).toBe(true);
+        expect(result2).toBe(true);
+        expect(result3).toBe(true);
+      });
+
+      it('returns `true` for either `boolean`', async () => {
+        const result1 = isEmpty(false);
+        const result2 = isEmpty(true);
+
+        expect(result1).toBe(true);
+        expect(result2).toBe(true);
+      });
+
+      it('returns `true` for any `number`', async () => {
+        const result1 = isEmpty(-0);
+        const result2 = isEmpty(0);
+        const result3 = isEmpty(-1);
+        const result4 = isEmpty(1);
+        const result5 = isEmpty(12.34);
+        const result6 = isEmpty(NaN);
+        const result7 = isEmpty(Infinity);
+        const result8 = isEmpty(1000n);
+
+        expect(result1).toBe(true);
+        expect(result2).toBe(true);
+        expect(result3).toBe(true);
+        expect(result4).toBe(true);
+        expect(result5).toBe(true);
+        expect(result6).toBe(true);
+        expect(result7).toBe(true);
+        expect(result8).toBe(true);
+      });
+    });
+
+    describe('arguments with `length` property', () => {
+      it('returns `true` for an empty `array`', async () => {
+        const result = isEmpty([]);
+        expect(result).toBe(true);
+      });
+
+      it('returns `false` for a populated `array`', async () => {
+        const result = isEmpty([0, false, 1000n]);
+        expect(result).toBe(false);
+      });
+
+      it('returns `true` for an empty `string`', async () => {
+        const result = isEmpty('');
+        expect(result).toBe(true);
+      });
+
+      it('returns `false` for a populated `string`', async () => {
+        const result = isEmpty('abc');
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('arguments with `size` property', () => {
+      it('returns `true` for an empty `Map`', async () => {
+        const result = isEmpty(new Map());
+        expect(result).toBe(true);
+      });
+
+      it('returns `false` for a populated `Map`', async () => {
+        const result = isEmpty(
+          new Map([
+            ['foo', 'bar'],
+            ['hello', 'world'],
+          ]),
+        );
+        expect(result).toBe(false);
+      });
+
+      it('returns `true` for an empty `Set`', async () => {
+        const result = isEmpty(new Set());
+        expect(result).toBe(true);
+      });
+
+      it('returns `false` for a populated `Set`', async () => {
+        const result = isEmpty(new Set([0, false, 1000n]));
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('object arguments', () => {
+      it('returns `true` for an empty object', async () => {
+        const result = isEmpty({});
+        expect(result).toBe(true);
+      });
+
+      it('returns `true` for a filtered object that has no keys', async () => {
+        const mockObj = objFilterNullish({
+          beef: null,
+          tools: undefined,
+        });
+        const result = isEmpty(mockObj);
+
+        expect(result).toBe(true);
+      });
+
+      it('returns `false` for a filtered object that has keys', async () => {
+        const mockObj = objFilterNullish({
+          foo: 1,
+          bar: 2,
+          beef: true,
+          chimi: false,
+          ear: null,
+          wurm: undefined,
+          chicken: 0,
+          friendship: Infinity,
+        });
+        const result = isEmpty(mockObj);
+
+        expect(result).toBe(false);
+      });
+    });
+  });
+});

--- a/src/tests/wait.test.ts
+++ b/src/tests/wait.test.ts
@@ -1,14 +1,134 @@
-import {describe, it} from 'vitest';
+import {describe, it, expect, vi} from 'vitest';
 
-// TODO: Finish these tests.
-// import {debounce, sleep} from '../support';
+import {debounce, sleep, throttle} from '../wait';
 
 describe('wait utilities', () => {
-  describe('debounce()', () => {
-    it.todo('does not execute more than the timeout allows');
+  // TODO: Figure out how to resolve these tests.
+  describe.skip('sleep()', () => {
+    it('resolves immediately by default', async () => {
+      const start = Date.now();
+
+      await sleep();
+
+      const end = Date.now();
+      const elapsedTime = end - start;
+
+      expect(elapsedTime).toBeLessThan(8);
+    });
+
+    it('resolves immediately if delay is 0', async () => {
+      const start = Date.now();
+
+      await sleep(0);
+
+      const end = Date.now();
+      const elapsedTime = end - start;
+
+      expect(elapsedTime).toBeLessThan(8);
+    });
+
+    it('resolves after the provided delay', async () => {
+      const mockDelayMs = 123;
+      const start = Date.now();
+
+      await sleep(mockDelayMs);
+
+      const end = Date.now();
+      const elapsed = end - start;
+
+      expect(elapsed).toBeGreaterThanOrEqual(mockDelayMs);
+    });
   });
 
-  describe('sleep()', () => {
-    it.todo('creates a Promise that resolves after the specified time');
+  describe('debounce()', () => {
+    const mockWaitMs = 1000;
+    vi.useFakeTimers();
+
+    it('does not execute more than the timeout allows', async () => {
+      const mockFn = vi.fn();
+      const debouncedFn = debounce(mockFn, mockWaitMs);
+
+      expect(mockFn).toHaveBeenCalledTimes(0);
+
+      debouncedFn();
+      debouncedFn();
+      debouncedFn();
+
+      expect(mockFn).toHaveBeenCalledTimes(0);
+      vi.advanceTimersByTime(mockWaitMs / 2);
+
+      debouncedFn();
+
+      expect(mockFn).toHaveBeenCalledTimes(0);
+      vi.advanceTimersByTime(mockWaitMs);
+
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      vi.advanceTimersByTime(mockWaitMs * 2);
+
+      expect(mockFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('executes immediately followed by a timed execution', async () => {
+      const mockFn = vi.fn();
+      const debouncedFn = debounce(mockFn, mockWaitMs, true);
+
+      expect(mockFn).toHaveBeenCalledTimes(0);
+      debouncedFn();
+      expect(mockFn).toHaveBeenCalledTimes(1);
+
+      debouncedFn();
+      debouncedFn();
+      debouncedFn();
+
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      vi.advanceTimersByTime(mockWaitMs / 2);
+
+      debouncedFn();
+
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      vi.advanceTimersByTime(mockWaitMs);
+
+      expect(mockFn).toHaveBeenCalledTimes(2);
+      vi.advanceTimersByTime(mockWaitMs * 2);
+
+      expect(mockFn).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('throttle()', () => {
+    const mockWaitMs = 1000;
+    vi.useFakeTimers();
+
+    it('executes immediately followed by a queue limited to 1 more execution', async () => {
+      const mockFn = vi.fn();
+      const throttledFn = throttle(mockFn, mockWaitMs);
+
+      expect(mockFn).toHaveBeenCalledTimes(0);
+      throttledFn();
+      throttledFn();
+      throttledFn();
+
+      // `throttle` executes right away,
+      // and queues another callback for execution.
+      expect(mockFn).toHaveBeenCalledTimes(1);
+
+      // Enough time has not yet passed for that subsequent execution.
+      vi.advanceTimersByTime(mockWaitMs / 2);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+
+      // Enough time has now passed. We called `throttle` 3 times,
+      // but that `3rd` call was suppressed by the queue.
+      vi.advanceTimersByTime(mockWaitMs * 4);
+      expect(mockFn).toHaveBeenCalledTimes(2);
+
+      // We are now free to execute immediately again.
+      throttledFn();
+      expect(mockFn).toHaveBeenCalledTimes(3);
+
+      // Since we only called `throttle` once after the queue
+      // had been cleared, there were no more executions in the queue.
+      vi.advanceTimersByTime(mockWaitMs * 2);
+      expect(mockFn).toHaveBeenCalledTimes(3);
+    });
   });
 });

--- a/src/wait.ts
+++ b/src/wait.ts
@@ -1,20 +1,63 @@
+import type {TimeoutId} from './types';
+
+export async function sleep(ms = 0) {
+  return await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 // Consider switching to something like:
 // https://github.com/chodorowicz/ts-debounce
 export function debounce<T extends (...args: Parameters<T>) => ReturnType<T>>(
   callback: T,
-  timeout: number,
-): (...args: Parameters<T>) => void {
-  let timer: ReturnType<typeof setTimeout>;
+  waitMs = 0,
+  immediate = false,
+) {
+  let timeout: TimeoutId | undefined;
 
-  return (...args: Parameters<T>) => {
-    clearTimeout(timer);
-
-    timer = setTimeout(() => {
+  return function debounced(...args: Parameters<T>) {
+    function later() {
+      timeout = undefined;
       callback(...args);
-    }, timeout);
+    }
+
+    const leading = immediate && !timeout;
+
+    clearTimeout(timeout);
+    timeout = setTimeout(later, waitMs);
+
+    if (leading) callback(...args);
   };
 }
 
-export async function sleep(ms = 0) {
-  return await new Promise((resolve) => setTimeout(resolve, ms));
+// Ideally, we want a `throttle` that is "cancellable". Example:
+// we `throttle` a `window` resize, where we want the callback
+// to execute immediately, but then only execute again every `x` ms
+// while resizing is still ocurring. Once resizing ends, we want
+// to cancel any queued `callback` and immediately call again to finish.
+export function throttle<T extends (...args: Parameters<T>) => ReturnType<T>>(
+  callback: T,
+  intervalMs = 0,
+) {
+  let lastTimestamp = 0;
+  let timeout: TimeoutId | undefined;
+
+  return function throttled(...args: Parameters<T>) {
+    const now = Date.now();
+    const elapsed = now - lastTimestamp;
+
+    if (!lastTimestamp || elapsed >= intervalMs) {
+      // If it's been longer than `intervalMs` since the last execution,
+      // execute the callback.
+      callback(...args);
+      lastTimestamp = now;
+    } else if (!timeout) {
+      // If it's within the `intervalMs` and no timeout is set,
+      // set a timeout to execute the function.
+      timeout = setTimeout(() => {
+        callback(...args);
+
+        lastTimestamp = Date.now();
+        timeout = undefined;
+      }, intervalMs - elapsed);
+    }
+  };
 }


### PR DESCRIPTION
Just a few small additions. Nothing should be breaking for `debounce`.